### PR TITLE
fix: lms course progress update issue

### DIFF
--- a/one_lms/hooks.py
+++ b/one_lms/hooks.py
@@ -211,7 +211,7 @@ after_migrate = [
 
 override_whitelisted_methods = {
 	"lms.lms.doctype.lms_assignment_submission.lms_assignment_submission.upload_assignment": "one_lms.overrides.lms_assignment_submission.upload_assignment",
-	"lms.lms.doctype.course_lesson.course_lesson.save_progress": "one_lms.overrides.course_lesson.save_progress",
+	#"lms.lms.doctype.course_lesson.course_lesson.save_progress": "one_lms.overrides.course_lesson.save_progress",
 	"lms.lms.doctype.lms_certificate.lms_certificate.create_certificate": "one_lms.overrides.lms_certificate.create_certificate"
 }
 

--- a/one_lms/overrides/course_lesson.py
+++ b/one_lms/overrides/course_lesson.py
@@ -2,7 +2,7 @@ import frappe
 from lms.lms.utils import get_course_progress
 
 @frappe.whitelist()
-def save_progress(lesson, course, status):
+def save_progress(lesson, course):
 	membership = frappe.db.exists(
 		"LMS Enrollment", {"member": frappe.session.user, "course": course}
 	)
@@ -28,14 +28,14 @@ def save_progress(lesson, course, status):
 	filters = {"lesson": lesson, "owner": frappe.session.user, "course": course}
 	if frappe.db.exists("LMS Course Progress", filters):
 		doc = frappe.get_doc("LMS Course Progress", filters)
-		doc.status = status
+		doc.status = "Complete"
 		doc.save(ignore_permissions=True)
 	else:
 		frappe.get_doc(
 			{
 				"doctype": "LMS Course Progress",
 				"lesson": lesson,
-				"status": status,
+				"status": "Complete",
 				"member": frappe.session.user,
 			}
 		).save(ignore_permissions=True)


### PR DESCRIPTION
This pull request updates the way lesson progress is saved in the LMS system, simplifying the logic and ensuring that progress is always marked as "Complete". The override for the `save_progress` method is commented out in the hooks file, and the implementation is streamlined to remove the need to pass a status parameter.

**Lesson Progress Logic Changes:**

* The `save_progress` method in `one_lms/overrides/course_lesson.py` no longer requires a `status` parameter, and always sets the progress status to "Complete" instead of accepting a variable status. [[1]](diffhunk://#diff-80b59182b3580322415862112c246406d87c51eb305e65cc822268d7cb548269L5-R5) [[2]](diffhunk://#diff-80b59182b3580322415862112c246406d87c51eb305e65cc822268d7cb548269L31-R38)

**Configuration Changes:**

* The override for `course_lesson.save_progress` in `one_lms/hooks.py` is commented out, which disables the custom override for this method.