### PR TITLE
feat: reset course completion upon re enrollment of member

### DIFF
--- a/one_lms/hooks.py
+++ b/one_lms/hooks.py
@@ -222,7 +222,8 @@ override_doctype_class = {
 	"User": "one_lms.overrides.user.User",
 	"LMS Enrollment": "one_lms.overrides.lms_enrollment.LMSEnrollment",
 	"LMS Quiz Submission": "one_lms.overrides.lms_quiz_submission.LMSQuizSubmission",
-	"LMS Certificate": "one_lms.overrides.lms_certificate.LMSCertificate"
+	"LMS Certificate": "one_lms.overrides.lms_certificate.LMSCertificate",
+    
 }
 #
 # each overriding function accepts a `data` argument;

--- a/one_lms/hooks.py
+++ b/one_lms/hooks.py
@@ -223,7 +223,7 @@ override_doctype_class = {
 	"LMS Enrollment": "one_lms.overrides.lms_enrollment.LMSEnrollment",
 	"LMS Quiz Submission": "one_lms.overrides.lms_quiz_submission.LMSQuizSubmission",
 	"LMS Certificate": "one_lms.overrides.lms_certificate.LMSCertificate",
-    
+
 }
 #
 # each overriding function accepts a `data` argument;

--- a/one_lms/overrides/lms_enrollment.py
+++ b/one_lms/overrides/lms_enrollment.py
@@ -38,3 +38,18 @@ class LMSEnrollment(BaseLMSEnrollment):
             frappe.log_error(title="Error Notifying Employee", message=e)
 
     
+    def before_insert(self):
+        super().before_insert()
+        self.reset_course_progress()
+
+    def reset_course_progress(self):
+        if not frappe.db.get_value("LMS Course", self.course, "allow_reenrollments"):
+            return
+        if not frappe.db.exists("LMS Enrollment", {"course": self.course, "member": self.member}):
+            return
+        frappe.db.sql(
+            "UPDATE `tabLMS Course Progress` SET status = 'Incomplete' WHERE course = %s AND member = %s",
+            (self.course, self.member)
+        )
+
+    


### PR DESCRIPTION
Re-enrollment progress reset
When a user is re-enrolled in a course that has allow_reenrollments enabled, all their existing LMS Course Progress records for that course are reset to Incomplete before the new enrollment is created. This ensures learners start fresh without stale completion data carrying over.


https://one-fm.com/app/hd-ticket/18423