### PR TITLE
feat: add AI Agent beta trigger workflow for multi-repo support

### DIFF
--- a/.github/workflows/agent-trigger-beta.yml
+++ b/.github/workflows/agent-trigger-beta.yml
@@ -1,0 +1,131 @@
+name: "🧪 Trigger AI Agent Beta (V2)"
+
+on:
+  issues:
+    types: [opened, reopened, labeled]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: 'Issue number to solve (e.g. 42)'
+        required: true
+        type: string
+      base_branch:
+        description: 'Base branch (default: staging)'
+        required: false
+        default: 'staging'
+        type: string
+
+jobs:
+  invoke-agent-v2:
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.event.inputs.issue_number || github.event.issue.number }}
+      cancel-in-progress: true
+
+    if: >-
+      github.event_name == 'workflow_dispatch' || 
+      (github.event_name == 'issues' && github.event.action != 'labeled' && (contains(github.event.issue.labels.*.name, 'onefm_beta_staging') || contains(github.event.issue.labels.*.name, 'onefm_beta_hotfix'))) ||
+      (github.event_name == 'issues' && github.event.action == 'labeled' && (github.event.label.name == 'onefm_beta_staging' || github.event.label.name == 'onefm_beta_hotfix'))
+    
+    runs-on: ubuntu-latest
+    
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: 🔐 Check User Permission
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          PERMISSION=$(gh api "repos/${{ github.repository }}/collaborators/$ACTOR/permission" --jq '.permission')
+          if [[ "$PERMISSION" != "admin" && "$PERMISSION" != "write" ]]; then
+            echo "Error: User $ACTOR does not have write access."
+            exit 1
+          fi
+
+      - name: 🔐 Authenticate with Google Cloud
+        id: auth
+        uses: google-github-actions/auth@55bd3a7c6e2ae7cf1877fd1ccb9d54c0503c457c # v2.1.2
+        with:
+          token_format: 'id_token'
+          id_token_audience: ${{ secrets.CLOUD_RUN_URL_V2 }}
+          id_token_include_email: true
+          workload_identity_provider: ${{ secrets.GCP_WIDP }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: 🛠️ Set up gcloud CLI
+        uses: google-github-actions/setup-gcloud@98ddc00a17442e89a24bbf282954a3b65ce6d200 # v2.1.0
+
+      - name: 🤖 Invoke Agent V2 on Cloud Run
+        env:
+          CLOUD_RUN_URL: ${{ secrets.CLOUD_RUN_URL_V2 }}
+          ISSUE_NUM: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.issue_number || github.event.issue.number }}
+          ACTOR: ${{ github.actor }}
+          GCP_ID_TOKEN: ${{ steps.auth.outputs.id_token }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          if ! [[ "$ISSUE_NUM" =~ ^[0-9]+$ ]]; then
+            echo "Error: Issue number '$ISSUE_NUM' is not a valid number."
+            exit 1
+          fi
+
+          BASE_BRANCH="staging"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            BASE_BRANCH="${{ github.event.inputs.base_branch }}"
+          elif [[ "${{ github.event.label.name }}" == "onefm_beta_hotfix" ]] || \
+               echo '${{ toJSON(github.event.issue.labels.*.name) }}' | jq -e '. | index("onefm_beta_hotfix")' > /dev/null 2>&1; then
+            BASE_BRANCH="version-15"
+          fi
+
+          echo "Connecting to V2: $CLOUD_RUN_URL"
+          echo "Repository: $REPOSITORY"
+          echo "Requesting fix for Issue #$ISSUE_NUM (base: $BASE_BRANCH)"
+          echo ""
+          echo "💡 NOTE: The AI agent can take 2-15 minutes to complete its reasoning loop."
+          echo "📖 VIEW REAL-TIME LOGS HERE:"
+          echo "https://console.cloud.google.com/run/detail/${{ secrets.GCP_LOCATION || 'us-central1' }}/onefm-agent-v2/logs?project=${{ secrets.GCP_PROJECT_ID || 'ai-agents-10' }}"
+          echo ""
+
+          PAYLOAD=$(jq -n \
+            --arg input "Solve GitHub issue #$ISSUE_NUM" \
+            --argjson issue_number "$ISSUE_NUM" \
+            --arg requester "$ACTOR" \
+            --arg base_branch "$BASE_BRANCH" \
+            --arg repository "$REPOSITORY" \
+            '{input: $input, issue_number: $issue_number, requester: $requester, base_branch: $base_branch, repository: $repository}')
+
+          MAX_ATTEMPTS=8
+          ATTEMPT=0
+          WAIT=15
+
+          while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
+            ATTEMPT=$((ATTEMPT + 1))
+            echo "Attempt $ATTEMPT/$MAX_ATTEMPTS — calling ${CLOUD_RUN_URL}/query..."
+
+            HTTP_CODE=$(curl -s -o /tmp/agent_response.json -w "%{http_code}" \
+              -X POST "${CLOUD_RUN_URL}/query" \
+              -H "Authorization: Bearer $GCP_ID_TOKEN" \
+              -H "Content-Type: application/json" \
+              -d "$PAYLOAD")
+
+            echo "HTTP $HTTP_CODE — Response: $(cat /tmp/agent_response.json)"
+
+            if [ "$HTTP_CODE" -eq 200 ] || [ "$HTTP_CODE" -eq 202 ]; then
+              echo "✅ Agent accepted the request. Pipeline started for issue #$ISSUE_NUM."
+              break
+            elif [ "$HTTP_CODE" -eq 503 ]; then
+              if [ $ATTEMPT -lt $MAX_ATTEMPTS ]; then
+                echo "⏳ Container busy — waiting ${WAIT}s for Cloud Run to scale..."
+                sleep $WAIT
+                WAIT=$(( WAIT * 2 > 60 ? 60 : WAIT * 2 ))
+              else
+                echo "❌ Container still busy after $MAX_ATTEMPTS attempts."
+                exit 1
+              fi
+            else
+              echo "❌ Unexpected HTTP $HTTP_CODE from agent."
+              cat /tmp/agent_response.json
+              exit 1
+            fi
+          done


### PR DESCRIPTION
- Sends repository and issue_number in payload to Cloud Run agent
- Uses ${{ github.repository }} for automatic repo detection
- Supports label-based triggers (onefm_beta_staging, onefm_beta_hotfix)
- Supports manual workflow_dispatch with issue number input